### PR TITLE
Fix relay when using same hash for contexts

### DIFF
--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -1407,6 +1407,7 @@ ngx_rtmp_relay_close(ngx_rtmp_session_t *s)
     for (; *cctx && *cctx != ctx; cctx = &(*cctx)->next);
     if (*cctx) {
         *cctx = ctx->next;
+        ctx->next = NULL; // Reset next for when context gets reused.
     }
 }
 


### PR DESCRIPTION
This PR fixes relay when multiple streams have the same hash and next is never reset for the context.

If this doesn't get reset then when this cached context gets used again here:

https://github.com/boxcast/nginx-rtmp-module/blob/b47c376b67ae745adc1bd14539e4b32efe3f0bb5/ngx_rtmp_relay_module.c#L541-L548

It still has a valid `next` value which breaks the logic here (there will be no `public_ctx` and depending on the order of connections it will enter an infinite loop):

https://github.com/boxcast/nginx-rtmp-module/blob/b47c376b67ae745adc1bd14539e4b32efe3f0bb5/ngx_rtmp_relay_module.c#L590-L606